### PR TITLE
PHP 8.0 support 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - 8.0snapshot
 
 env:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-    - 5.5.9
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
+    - 7.2
+    - 7.3
+    - 7.4
 
 env:
     matrix:
@@ -18,8 +16,3 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi
-
-after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,14 @@
             "Tylercd100\\Monolog\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
-        "php": "^7.0",
+        "php": "^7.2|^8.0",
         "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^8.2.3|^9.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.4|^7.0",
-        "monolog/monolog": "^1.12 || ^2.0"
+        "php": "^7.0",
+        "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^5.0"
     },
     "authors": [
         {

--- a/src/Handler/SMSHandler.php
+++ b/src/Handler/SMSHandler.php
@@ -3,6 +3,7 @@
 namespace Tylercd100\Monolog\Handler;
 
 use Exception;
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\SocketHandler;
 use Monolog\Logger;
 use Tylercd100\Monolog\Formatter\SMSFormatter;
@@ -81,7 +82,7 @@ abstract class SMSHandler extends SocketHandler
      * @param  array  $record
      * @return string
      */
-    protected function generateDataStream($record)
+    protected function generateDataStream(array $record) :string
     {
         $content = $this->buildContent($record);
         return $this->buildHeader($content) . $content;
@@ -133,7 +134,7 @@ abstract class SMSHandler extends SocketHandler
      *
      * @param array $record
      */
-    protected function write(array $record)
+    protected function write(array $record) :void
     {
         parent::write($record);
         $this->closeSocket();
@@ -142,7 +143,7 @@ abstract class SMSHandler extends SocketHandler
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         return new SMSFormatter();
     }

--- a/tests/ClickatellHandlerTest.php
+++ b/tests/ClickatellHandlerTest.php
@@ -14,7 +14,7 @@ class ClickatellHandlerTest extends TestCase
 
     /** @var  ClickatellHandler */
     private $handler;
-    
+
     public function testCanBeInstantiatedAndProvidesDefaultFormatter()
     {
         $handler = new ClickatellHandler('token', '+15555555555', '+16666666666');
@@ -97,11 +97,10 @@ class ClickatellHandlerTest extends TestCase
     {
         $constructorArgs = array($authToken, $fromNumber, $toNumber, Logger::DEBUG, true, true, $host, $version);
         $this->res = fopen('php://memory', 'a');
-        $this->handler = $this->getMock(
-            '\Tylercd100\Monolog\Handler\ClickatellHandler',
-            array('fsockopen', 'streamSetTimeout', 'closeSocket'),
-            $constructorArgs
-        );
+        $this->handler = $this->getMockBuilder(ClickatellHandler::class)
+            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->setConstructorArgs($constructorArgs)
+            ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
         $reflectionProperty->setAccessible(true);

--- a/tests/ClickatellHandlerTest.php
+++ b/tests/ClickatellHandlerTest.php
@@ -20,14 +20,14 @@ class ClickatellHandlerTest extends TestCase
         $handler = new ClickatellHandler('token', '+15555555555', '+16666666666');
 
         $this->assertInstanceOf('Tylercd100\\Monolog\\Formatter\\SMSFormatter', $handler->getFormatter());
-        $this->assertAttributeEquals('token',        'authToken',  $handler);
-        $this->assertAttributeEquals('+15555555555', 'fromNumber', $handler);
-        $this->assertAttributeEquals('+16666666666', 'toNumber',   $handler);
+        $this->assertEquals('token',        $this->accessProtected($handler, 'authToken'));
+        $this->assertEquals('+15555555555', $this->accessProtected($handler, 'fromNumber'));
+        $this->assertEquals('+16666666666', $this->accessProtected($handler, 'toNumber'));
     }
 
     public function testItThrowsExceptionWhenUsingDifferentVersionOtherThanV1()
     {
-        $this->setExpectedException(Exception::class);
+        $this->expectException(Exception::class);
         $handler = new ClickatellHandler('token', 'auth_id', '+15555555555', '+16666666666', Logger::CRITICAL, true, true, 'twilio.foo.bar', 'v2');
     }
 
@@ -38,7 +38,7 @@ class ClickatellHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/messages HTTP\/1.1\\r\\nHost: platform.clickatell.com\\r\\nAuthorization: token\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/messages HTTP\/1.1\\r\\nHost: platform.clickatell.com\\r\\nAuthorization: token\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -50,7 +50,7 @@ class ClickatellHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/messages HTTP\/1.1\\r\\nHost: twilio.foo.bar\\r\\nAuthorization: token\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/messages HTTP\/1.1\\r\\nHost: twilio.foo.bar\\r\\nAuthorization: token\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -60,7 +60,7 @@ class ClickatellHandlerTest extends TestCase
      */
     public function testWriteContent($content)
     {
-        $this->assertRegexp('/{"content":"test1","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
+        $this->assertMatchesRegularExpression('/{"content":"test1","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
     }
 
     public function testWriteContentV1WithoutToAndFromNumbers()
@@ -70,7 +70,7 @@ class ClickatellHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"content":"test1","to":\[null\]}/', $content);
+        $this->assertMatchesRegularExpression('/{"content":"test1","to":\[null\]}/', $content);
 
         return $content;
     }
@@ -80,7 +80,7 @@ class ClickatellHandlerTest extends TestCase
      */
     public function testWriteContentNotify($content)
     {
-        $this->assertRegexp('/{"content":"test1","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
+        $this->assertMatchesRegularExpression('/{"content":"test1","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
     }
 
     public function testWriteWithComplexMessage()
@@ -90,7 +90,7 @@ class ClickatellHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"content":"Backup of database example finished in 16 minutes\.","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
+        $this->assertMatchesRegularExpression('/{"content":"Backup of database example finished in 16 minutes\.","to":\["\+16666666666"\],"from":"\+15555555555"}/', $content);
     }
 
     private function createHandler($authToken = 'token', $fromNumber = '+15555555555', $toNumber = '+16666666666', $level = Logger::CRITICAL, $bubble = true, $useSSL = true, $host = 'platform.clickatell.com', $version = ClickatellHandler::API_V1)

--- a/tests/PlivoHandlerTest.php
+++ b/tests/PlivoHandlerTest.php
@@ -19,15 +19,15 @@ class PlivoHandlerTest extends TestCase
         $handler = new PlivoHandler('token', 'auth_id', '+15555555555', '+16666666666');
 
         $this->assertInstanceOf('Tylercd100\\Monolog\\Formatter\\SMSFormatter', $handler->getFormatter());
-        $this->assertAttributeEquals('token',        'authToken',  $handler);
-        $this->assertAttributeEquals('auth_id',      'authId',     $handler);
-        $this->assertAttributeEquals('+15555555555', 'fromNumber', $handler);
-        $this->assertAttributeEquals('+16666666666', 'toNumber',   $handler);
+        $this->assertEquals('token',        $this->accessProtected($handler, 'authToken'));
+        $this->assertEquals('auth_id',      $this->accessProtected($handler, 'authId'));
+        $this->assertEquals('+15555555555', $this->accessProtected($handler, 'fromNumber'));
+        $this->assertEquals('+16666666666', $this->accessProtected($handler, 'toNumber'));
     }
 
     public function testItThrowsExceptionWhenUsingDifferentVersionOtherThanV1()
     {
-        $this->setExpectedException(Exception::class);
+        $this->expectException(Exception::class);
         $handler = new PlivoHandler('token', 'auth_id', '+15555555555', '+16666666666', Logger::CRITICAL, true, true, 'plivo.foo.bar', 'v2');
     }
 
@@ -38,7 +38,7 @@ class PlivoHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/v1\/Account\/auth_id\/Message\/ HTTP\/1.1\\r\\nHost: api.plivo.com\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/v1\/Account\/auth_id\/Message\/ HTTP\/1.1\\r\\nHost: api.plivo.com\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -50,7 +50,7 @@ class PlivoHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/v1\/Account\/auth_id\/Message\/ HTTP\/1.1\\r\\nHost: plivo.foo.bar\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/v1\/Account\/auth_id\/Message\/ HTTP\/1.1\\r\\nHost: plivo.foo.bar\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -60,7 +60,7 @@ class PlivoHandlerTest extends TestCase
      */
     public function testWriteContent($content)
     {
-        $this->assertRegexp('/{"src":"\+15555555555","dst":"\+16666666666","text":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"src":"\+15555555555","dst":"\+16666666666","text":"test1"}/', $content);
     }
 
     public function testWriteContentV1WithoutToAndFromNumbers()
@@ -70,7 +70,7 @@ class PlivoHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"src":false,"dst":null,"text":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"src":false,"dst":null,"text":"test1"}/', $content);
 
         return $content;
     }
@@ -80,7 +80,7 @@ class PlivoHandlerTest extends TestCase
      */
     public function testWriteContentNotify($content)
     {
-        $this->assertRegexp('/{"src":"\+15555555555","dst":"\+16666666666","text":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"src":"\+15555555555","dst":"\+16666666666","text":"test1"}/', $content);
     }
 
     public function testWriteWithComplexMessage()
@@ -90,7 +90,7 @@ class PlivoHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"src":"\+15555555555","dst":"\+16666666666","text":"Backup of database example finished in 16 minutes\."}/', $content);
+        $this->assertMatchesRegularExpression('/{"src":"\+15555555555","dst":"\+16666666666","text":"Backup of database example finished in 16 minutes\."}/', $content);
     }
 
     private function createHandler($authToken = 'token', $authId = 'auth_id', $fromNumber = '+15555555555', $toNumber = '+16666666666', $level = Logger::CRITICAL, $bubble = true, $useSSL = true, $host = 'api.plivo.com', $version = PlivoHandler::API_V1)

--- a/tests/PlivoHandlerTest.php
+++ b/tests/PlivoHandlerTest.php
@@ -13,7 +13,7 @@ class PlivoHandlerTest extends TestCase
     private $res;
     /** @var  PlivoHandler */
     private $handler;
-    
+
     public function testCanBeInstantiatedAndProvidesDefaultFormatter()
     {
         $handler = new PlivoHandler('token', 'auth_id', '+15555555555', '+16666666666');
@@ -97,11 +97,10 @@ class PlivoHandlerTest extends TestCase
     {
         $constructorArgs = array($authToken, $authId, $fromNumber, $toNumber, Logger::DEBUG, true, true, $host, $version);
         $this->res = fopen('php://memory', 'a');
-        $this->handler = $this->getMock(
-            '\Tylercd100\Monolog\Handler\PlivoHandler',
-            array('fsockopen', 'streamSetTimeout', 'closeSocket'),
-            $constructorArgs
-        );
+        $this->handler = $this->getMockBuilder(PlivoHandler::class)
+            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->setConstructorArgs($constructorArgs)
+            ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
         $reflectionProperty->setAccessible(true);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,7 @@
 namespace Tylercd100\Monolog\Tests;
 
 use Monolog\Logger;
+use Monolog\Formatter\FormatterInterface;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
@@ -50,7 +51,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function getIdentityFormatter()
     {
-        $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
+        $formatter = $this->getMockBuilder(FormatterInterface::class)->getMock();
         $formatter->expects($this->any())
             ->method('format')
             ->will($this->returnCallback(function ($record) { return $record['message']; }));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,10 +11,12 @@
 
 namespace Tylercd100\Monolog\Tests;
 
+use ReflectionClass;
 use Monolog\Logger;
 use Monolog\Formatter\FormatterInterface;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     /**
      * @return array Record
@@ -54,8 +56,42 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $formatter = $this->getMockBuilder(FormatterInterface::class)->getMock();
         $formatter->expects($this->any())
             ->method('format')
-            ->will($this->returnCallback(function ($record) { return $record['message']; }));
+            ->will(
+                $this->returnCallback(function ($record) {
+                    return $record['message'];
+                })
+            );
 
         return $formatter;
+    }
+
+    /**
+     * Helper to return protected or private property value of an object
+     *
+     * @param  mixed  $object
+     * @param  string $property
+     * @return mixed
+     */
+    protected function accessProtected($object, $property)
+    {
+        $reflection = new ReflectionClass($object);
+        $propertyReflection = $reflection->getProperty($property);
+        $propertyReflection->setAccessible(true);
+
+        return $propertyReflection->getValue($object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(PHPUnitTestCase::class, 'assertMatchesRegularExpression')) {
+            // For PHPUnit >= 9
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            // For PHPUnit < 9
+            static::assertRegExp($pattern, $string, $message);
+        }
     }
 }

--- a/tests/TwilioHandlerTest.php
+++ b/tests/TwilioHandlerTest.php
@@ -19,15 +19,15 @@ class TwilioHandlerTest extends TestCase
         $handler = new TwilioHandler('token', 'auth_id', '+15555555555', '+16666666666');
 
         $this->assertInstanceOf('Tylercd100\\Monolog\\Formatter\\SMSFormatter', $handler->getFormatter());
-        $this->assertAttributeEquals('token',        'authToken',  $handler);
-        $this->assertAttributeEquals('auth_id',      'authId',     $handler);
-        $this->assertAttributeEquals('+15555555555', 'fromNumber', $handler);
-        $this->assertAttributeEquals('+16666666666', 'toNumber',   $handler);
+        $this->assertEquals('token',        $this->accessProtected($handler, 'authToken'));
+        $this->assertEquals('auth_id',      $this->accessProtected($handler, 'authId'));
+        $this->assertEquals('+15555555555', $this->accessProtected($handler, 'fromNumber'));
+        $this->assertEquals('+16666666666', $this->accessProtected($handler, 'toNumber'));
     }
 
     public function testItThrowsExceptionWhenUsingDifferentVersionOtherThanV1()
     {
-        $this->setExpectedException(Exception::class);
+        $this->expectException(Exception::class);
         $handler = new TwilioHandler('token', 'auth_id', '+15555555555', '+16666666666', Logger::CRITICAL, true, true, 'twilio.foo.bar', 'v2');
     }
 
@@ -38,7 +38,7 @@ class TwilioHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/2010-04-01\/Accounts\/auth_id\/Messages\.json HTTP\/1.1\\r\\nHost: api.twilio.com\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/2010-04-01\/Accounts\/auth_id\/Messages\.json HTTP\/1.1\\r\\nHost: api.twilio.com\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -50,7 +50,7 @@ class TwilioHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/POST \/2010-04-01\/Accounts\/auth_id\/Messages.json HTTP\/1.1\\r\\nHost: twilio.foo.bar\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
+        $this->assertMatchesRegularExpression('/POST \/2010-04-01\/Accounts\/auth_id\/Messages.json HTTP\/1.1\\r\\nHost: twilio.foo.bar\\r\\nAuthorization: Basic YXV0aF9pZDp0b2tlbg==\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n/', $content);
 
         return $content;
     }
@@ -60,7 +60,7 @@ class TwilioHandlerTest extends TestCase
      */
     public function testWriteContent($content)
     {
-        $this->assertRegexp('/{"From":"\+15555555555","To":"\+16666666666","Body":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"From":"\+15555555555","To":"\+16666666666","Body":"test1"}/', $content);
     }
 
     public function testWriteContentV1WithoutToAndFromNumbers()
@@ -70,7 +70,7 @@ class TwilioHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"From":false,"To":null,"Body":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"From":false,"To":null,"Body":"test1"}/', $content);
 
         return $content;
     }
@@ -80,7 +80,7 @@ class TwilioHandlerTest extends TestCase
      */
     public function testWriteContentNotify($content)
     {
-        $this->assertRegexp('/{"From":"\+15555555555","To":"\+16666666666","Body":"test1"}/', $content);
+        $this->assertMatchesRegularExpression('/{"From":"\+15555555555","To":"\+16666666666","Body":"test1"}/', $content);
     }
 
     public function testWriteWithComplexMessage()
@@ -90,7 +90,7 @@ class TwilioHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/{"From":"\+15555555555","To":"\+16666666666","Body":"Backup of database example finished in 16 minutes\."}/', $content);
+        $this->assertMatchesRegularExpression('/{"From":"\+15555555555","To":"\+16666666666","Body":"Backup of database example finished in 16 minutes\."}/', $content);
     }
 
     private function createHandler($authToken = 'token', $authId = 'auth_id', $fromNumber = '+15555555555', $toNumber = '+16666666666', $level = Logger::CRITICAL, $bubble = true, $useSSL = true, $host = 'api.twilio.com', $version = TwilioHandler::API_V1)

--- a/tests/TwilioHandlerTest.php
+++ b/tests/TwilioHandlerTest.php
@@ -13,7 +13,7 @@ class TwilioHandlerTest extends TestCase
     private $res;
     /** @var  TwilioHandler */
     private $handler;
-    
+
     public function testCanBeInstantiatedAndProvidesDefaultFormatter()
     {
         $handler = new TwilioHandler('token', 'auth_id', '+15555555555', '+16666666666');
@@ -97,11 +97,10 @@ class TwilioHandlerTest extends TestCase
     {
         $constructorArgs = array($authToken, $authId, $fromNumber, $toNumber, Logger::DEBUG, true, true, $host, $version);
         $this->res = fopen('php://memory', 'a');
-        $this->handler = $this->getMock(
-            '\Tylercd100\Monolog\Handler\TwilioHandler',
-            array('fsockopen', 'streamSetTimeout', 'closeSocket'),
-            $constructorArgs
-        );
+        $this->handler = $this->getMockBuilder(TwilioHandler::class)
+            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->setConstructorArgs($constructorArgs)
+            ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
         $reflectionProperty->setAccessible(true);


### PR DESCRIPTION
* Add PHP 7.2, 7.3, 7.4 and 8.0 support
* Upgrade from Monolog 1.12 to 2.0
* Update PHPUnit tests
* Drop PHP 5.5, 5.6, 7.0, 7.1 and HHVM support

If this pull request is merged, can you tag it with the `2.0.0` version, please?